### PR TITLE
Efficiency restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+data
 __pycache__/
 *.py[cod]
 *$py.class

--- a/FFLayer.py
+++ b/FFLayer.py
@@ -12,7 +12,7 @@ class FFLayer(Linear):
         activation: Module = ReLU,
         optimizer: Optimizer = None,
         threshold: float = 2.0,
-        num_epochs: int = 1000,
+        num_epochs: int = 1,
         bias=True,
         device=None,
         dtype=None,
@@ -33,12 +33,10 @@ class FFLayer(Linear):
         )
 
     def forward(self, *input):
-        # self.to('cuda')
         if self.training:
             assert len(input) == 2, "Pass both positive and negative input"
             x_pos, x_neg = tuple(input)
 
-            # for _ in tqdm(range(self.num_epochs)):
             for _ in range(self.num_epochs):
                 g_pos = self.forward_pass(x_pos).pow(2).mean(1)
                 g_neg = self.forward_pass(x_neg).pow(2).mean(1)
@@ -56,12 +54,8 @@ class FFLayer(Linear):
                 loss.backward(retain_graph=True)
                 self.opt.step()
             x1, x2 = self.forward_pass(x_pos), self.forward_pass(x_neg)
-            # return self.forward_pass(x_pos), self.forward_pass(x_neg)
-            # self.to('cpu')
             return x1, x2
         else:
             assert len(input) == 1, "Pass only 1 argument in eval mode"
-            x1 = self.forward_pass(input[0])
-            # return self.forward_pass(input[0])
-            # self.to('cpu')
-            return x1
+            r = self.forward_pass(input[0])
+            return r

--- a/FFLayer.py
+++ b/FFLayer.py
@@ -33,11 +33,13 @@ class FFLayer(Linear):
         )
 
     def forward(self, *input):
+        # self.to('cuda')
         if self.training:
             assert len(input) == 2, "Pass both positive and negative input"
             x_pos, x_neg = tuple(input)
 
-            for _ in tqdm(range(self.num_epochs)):
+            # for _ in tqdm(range(self.num_epochs)):
+            for _ in range(self.num_epochs):
                 g_pos = self.forward_pass(x_pos).pow(2).mean(1)
                 g_neg = self.forward_pass(x_neg).pow(2).mean(1)
                 # The following loss pushes pos (neg) samples to
@@ -53,8 +55,13 @@ class FFLayer(Linear):
                 # is not considered backpropagation.
                 loss.backward(retain_graph=True)
                 self.opt.step()
-
-            return self.forward_pass(x_pos), self.forward_pass(x_neg)
+            x1, x2 = self.forward_pass(x_pos), self.forward_pass(x_neg)
+            # return self.forward_pass(x_pos), self.forward_pass(x_neg)
+            # self.to('cpu')
+            return x1, x2
         else:
             assert len(input) == 1, "Pass only 1 argument in eval mode"
-            return self.forward_pass(input[0])
+            x1 = self.forward_pass(input[0])
+            # return self.forward_pass(input[0])
+            # self.to('cpu')
+            return x1

--- a/FFNetwork.py
+++ b/FFNetwork.py
@@ -2,10 +2,10 @@ from typing import Iterator
 import torch
 from torch.nn import Module
 from torch._jit_internal import _copy_to_script_wrapper
-import FFLayer
-import FFEncoding
+from FFLayer import FFLayer
+# import FFEncoding
 
-overlay_y_on_x = FFEncoding.overlay
+# overlay_y_on_x = FFEncoding.overlay
 
 
 class FFNetwork(torch.nn.Module):
@@ -32,9 +32,16 @@ class FFNetwork(torch.nn.Module):
         if self.training:
             assert len(input) == 2, "Pass both positive and negative input"
             x_pos, x_neg = tuple(input)
+            modules = []
             for i, module in enumerate(self.children()):
-                print("Training layer", i, "...")
+                # print("Training layer", i, "...")
+                # module.to('cuda')
+                modules.append(module)
+                # module.to('cuda')
                 x_pos, x_neg = module(x_pos, x_neg)
+                # x_pos = x_pos.detach()
+                # x_neg = x_neg.detach()
+                # module.to('cpu')
             return
         else:
             assert len(input) == 1, "Only pass the input data "

--- a/FFNetwork.py
+++ b/FFNetwork.py
@@ -26,6 +26,41 @@ class FFNetwork(torch.nn.Module):
     def __iter__(self) -> Iterator[Module]:
         return iter(self._modules.values())
 
+    def forward(self, *input):
+        if self.training:
+            assert len(input) == 2, "Pass both positive and negative input"
+            x_pos, x_neg = tuple(input)
+            for i, module in enumerate(self.children()):
+                print("Training layer", i, "...")
+                x_pos, x_neg = module(x_pos, x_neg)
+            return
+        else:
+            assert len(input) == 1, "Only pass the input data "
+            for module in self:
+                input = module(input)
+            return input
+
+
+class FFNetworkBatched(torch.nn.Module):
+    def __init__(self, dims):
+        super().__init__()
+        assert len(dims) >= 1, "len(dims) should be greater than equal to 1"
+        for d in range(len(dims) - 1):
+            self.add_module(str(d), FFLayer(dims[d], dims[d + 1], torch.nn.GELU()))
+
+    def __len__(self) -> int:
+        return len(self._modules)
+
+    @_copy_to_script_wrapper
+    def __dir__(self):
+        keys = super().__dir__()
+        keys = [key for key in keys if not key.isdigit()]
+        return keys
+
+    @_copy_to_script_wrapper
+    def __iter__(self) -> Iterator[Module]:
+        return iter(self._modules.values())
+
     def forward(self, input, device):
         if self.training:
             # Loop through all batches in dataset
@@ -41,9 +76,9 @@ class FFNetwork(torch.nn.Module):
                     x_pos, x_neg = module(x_pos, x_neg)
                     x_pos = x_pos.detach()
                     x_neg = x_neg.detach()
-                    x_pos, x_neg = x_pos.to('cpu'), x_neg.to('cpu')
+                    x_pos, x_neg = x_pos.to("cpu"), x_neg.to("cpu")
                     layer_data[i] = (x_pos, x_neg)
-                module.to('cpu')
+                module.to("cpu")
             return
         else:
             assert len(input) == 1, "Only pass the input data "

--- a/base.py
+++ b/base.py
@@ -57,8 +57,8 @@ def test_loop(model, test_loader, device):
     for x, y in test_loader:
         x, y = x.to(device), y.to(device)
         batch_error += calc_error(model, x, y, device)
-        x, y = x.to('cpu'), y.to('cpu')
-    
+        x, y = x.to("cpu"), y.to("cpu")
+
     avg_error = batch_error / len(test_loader)
     print(f"testing error: {avg_error}")
 
@@ -73,7 +73,7 @@ def eval_loop(model, x, device, encoding="overlay"):
                 module.to(device)
                 h = module(h)
                 goodness += [h.pow(2).mean(1)]
-                module.to('cpu')
+                module.to("cpu")
             goodness_per_label += [sum(goodness).unsqueeze(1)]
         goodness_per_label = torch.cat(goodness_per_label, 1)
         return goodness_per_label.argmax(1)
@@ -87,14 +87,16 @@ def calc_error(model, x, y, device) -> float:
 if __name__ == "__main__":
     # Define parameters
     EPOCHS = 10
-    BATCH_SIZE=50
+    BATCH_SIZE = 50
     TRAIN_BATCH_SIZE = BATCH_SIZE
     TEST_BATCH_SIZE = BATCH_SIZE
     encoding = "overlay"
     torch.manual_seed(1234)
 
     # Build train and test loaders
-    train_loader, test_loader = MNIST_loaders(train_batch_size=TRAIN_BATCH_SIZE, test_batch_size=TEST_BATCH_SIZE)
+    train_loader, test_loader = MNIST_loaders(
+        train_batch_size=TRAIN_BATCH_SIZE, test_batch_size=TEST_BATCH_SIZE
+    )
 
     # Define device
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -109,15 +111,13 @@ if __name__ == "__main__":
     # Encode true and false labels on images to create positive and negative data
     print("Encoding positive and negative data with correct and incorrect labels")
     for x, y in tqdm(train_loader):
-        x, y = x.to(device), y.to(device)
         x_pos, x_neg = None, None
         if encoding == "overlay":
             x_pos = overlay_y_on_x(x, y)
-            rand_mask = torch.randint(0, 9, y.size()).to(device)
+            rand_mask = torch.randint(0, 9, y.size())
             y_rnd = (y + rand_mask + 1) % 10
             x_neg = overlay_y_on_x(x, y_rnd)
-        x, y = x.to('cpu'), y.to('cpu')
-        x_pos, x_neg = x_pos.to('cpu'), x_neg.to('cpu')
+
         data_iter.append((x_pos, x_neg))
 
     # Train / test
@@ -129,4 +129,3 @@ if __name__ == "__main__":
         end = time.time()
         elapsed = end - start
         print(f"Completed epoch {epoch} in {elapsed} seconds")
-

--- a/base.py
+++ b/base.py
@@ -3,22 +3,15 @@ import torch
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, ToTensor, Normalize, Lambda
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from FFNetwork import FFNetwork
-import FFEncoding
-
-overlay_y_on_x = FFEncoding.overlay
-
-import matplotlib.pyplot as plt
-import torch
-from torchvision.datasets import MNIST
-from torchvision.transforms import Compose, ToTensor, Normalize, Lambda
-from torch.utils.data import DataLoader
+from FFEncoding import FFEncoding
 
 overlay_y_on_x = FFEncoding.overlay
 
 
-def MNIST_loaders(train_batch_size=50000, test_batch_size=10000):
+def MNIST_loaders(train_batch_size=1000, test_batch_size=1000):
     transform = Compose(
         [
             ToTensor(),
@@ -50,15 +43,37 @@ def visualize_sample(data, name="", idx=0):
     plt.show()
 
 
-def training_loop(model, x, y, encoding="overlay"):
-    x_pos, x_neg = None, None
-    if encoding == "overlay":
-        x_pos = overlay_y_on_x(x, y)
-        rand_mask = torch.randint(0, 9, y.size()).to(device)
-        y_rnd = (y + rand_mask + 1) % 10
-        x_neg = overlay_y_on_x(x, y_rnd)
-    model.train()
-    model(x_pos, x_neg)
+# def training_loop(model, x, y, encoding="overlay"):
+#     x_pos, x_neg = None, None
+#     if encoding == "overlay":
+#         x_pos = overlay_y_on_x(x, y)
+#         rand_mask = torch.randint(0, 9, y.size()).to(device)
+#         y_rnd = (y + rand_mask + 1) % 10
+#         x_neg = overlay_y_on_x(x, y_rnd)
+#     model.train()
+#     model(x_pos, x_neg)
+
+
+def training_loop(model, train_loader, device, encoding="overlay"):
+    print("Training loop")
+    model.to(device)
+    for i, (x, y) in enumerate(train_loader):
+        print(f"\nBatch {i} out of {len(train_loader)}")
+        x_pos, x_neg = None, None
+        if encoding == "overlay":
+            x_pos = overlay_y_on_x(x, y)
+            rand_mask = torch.randint(0, 9, y.size())
+            y_rnd = (y + rand_mask + 1) % 10
+            x_neg = overlay_y_on_x(x, y_rnd)
+        x_pos, x_neg = x_pos.to(device), x_neg.to(device)
+        # model.to(device)
+        model.train()
+        model(x_pos, x_neg)
+        # model.to('cpu')
+        error = calc_error(model, x, y, device)
+        print(f"Error {error}")
+    model.to('cpu')
+
 
 
 def eval_loop(model, x, encoding="overlay"):
@@ -68,16 +83,47 @@ def eval_loop(model, x, encoding="overlay"):
             h = overlay_y_on_x(x, label)
             goodness = []
             for module in model.children():
+                h = h.to(device)
+                # module.to(device)
                 h = module(h)
+                # module.to('cpu')
                 goodness += [h.pow(2).mean(1)]
             goodness_per_label += [sum(goodness).unsqueeze(1)]
         goodness_per_label = torch.cat(goodness_per_label, 1)
+        # print(f"goodness: {goodness_per_label}")
         return goodness_per_label.argmax(1)
 
 
-def calc_error(model, x, y) -> float:
+# def eval_loop(model, train_loader, encoding="overlay"):
+#     if encoding == "overlay":
+#         for x, _ in train_loader:
+#             for label in range(10):
+#                 h = overlay_y_on_x(x, label)
+#                 goodness = []
+#                 for module in model.children():
+#                     h = module(h)
+#                     goodness += h.pow(2).mean(1)
+                
+            
+
+def test_loop(model, test_loader, device):
     model.eval()
-    return 1 - eval_loop(model, x).eq(y).float().mean().item()
+    batch_error = 0
+    for x, y in test_loader:
+        x, y = x.to(device), y.to(device)
+        batch_error += calc_error(model, x, y)
+    
+    avg_error = batch_error / len(test_loader)
+    print(avg_error)
+
+def calc_error(model, x, y, device) -> float:
+    model.eval()
+    r1 = eval_loop(model, x)
+    r1 = r1.to('cuda')
+    y = y.to('cuda')
+    r2 = r1.eq(y).float().mean().item()
+    r = 1 - r2
+    return r
 
 
 torch.manual_seed(1234)
@@ -86,17 +132,19 @@ train_loader, test_loader = MNIST_loaders()
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 net = FFNetwork([784, 500, 500])
-net = net.to(device)
-x, y = next(iter(train_loader))
-x, y = x.to(device), y.to(device)
+# net = net.to(device)
+# x, y = next(iter(train_loader))
+# x, y = x.to(device), y.to(device)
 
-training_loop(net, x, y)
-net.eval()
-print(calc_error(net, x, y))
+# training_loop(net, x, y)
+training_loop(net, train_loader, device)
+# net.eval()
+# print(calc_error(net, x, y))
 
-x_te, y_te = next(iter(test_loader))
-x_te, y_te = x_te.cuda(), y_te.cuda()
+# x_te, y_te = next(iter(test_loader))
+# x_te, y_te = x_te.cuda(), y_te.cuda()
 
 # USE EVAL
-net.eval()
-print(calc_error(net, x_te, y_te))
+# net.eval()
+# print(calc_error(net, x_te, y_te))
+test_loop(net, test_loader, device)

--- a/base.py
+++ b/base.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import torch
+import time
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, ToTensor, Normalize, Lambda
 from torch.utils.data import DataLoader
@@ -11,7 +12,7 @@ from FFEncoding import FFEncoding
 overlay_y_on_x = FFEncoding.overlay
 
 
-def MNIST_loaders(train_batch_size=1000, test_batch_size=1000):
+def MNIST_loaders(train_batch_size=50, test_batch_size=50):
     transform = Compose(
         [
             ToTensor(),
@@ -43,108 +44,89 @@ def visualize_sample(data, name="", idx=0):
     plt.show()
 
 
-# def training_loop(model, x, y, encoding="overlay"):
-#     x_pos, x_neg = None, None
-#     if encoding == "overlay":
-#         x_pos = overlay_y_on_x(x, y)
-#         rand_mask = torch.randint(0, 9, y.size()).to(device)
-#         y_rnd = (y + rand_mask + 1) % 10
-#         x_neg = overlay_y_on_x(x, y_rnd)
-#     model.train()
-#     model(x_pos, x_neg)
+def training_loop(model, iterator, device, encoding="overlay"):
+    print("Training...")
+    model.train()
+    model(iterator, device)
 
 
-def training_loop(model, train_loader, device, encoding="overlay"):
-    print("Training loop")
-    model.to(device)
-    for i, (x, y) in enumerate(train_loader):
-        print(f"\nBatch {i} out of {len(train_loader)}")
-        x_pos, x_neg = None, None
-        if encoding == "overlay":
-            x_pos = overlay_y_on_x(x, y)
-            rand_mask = torch.randint(0, 9, y.size())
-            y_rnd = (y + rand_mask + 1) % 10
-            x_neg = overlay_y_on_x(x, y_rnd)
-        x_pos, x_neg = x_pos.to(device), x_neg.to(device)
-        # model.to(device)
-        model.train()
-        model(x_pos, x_neg)
-        # model.to('cpu')
-        error = calc_error(model, x, y, device)
-        print(f"Error {error}")
-    model.to('cpu')
+def test_loop(model, test_loader, device):
+    print("Evaluating...")
+    model.eval()
+    batch_error = 0
+    for x, y in test_loader:
+        x, y = x.to(device), y.to(device)
+        batch_error += calc_error(model, x, y, device)
+        x, y = x.to('cpu'), y.to('cpu')
+    
+    avg_error = batch_error / len(test_loader)
+    print(f"testing error: {avg_error}")
 
 
-
-def eval_loop(model, x, encoding="overlay"):
+def eval_loop(model, x, device, encoding="overlay"):
     if encoding == "overlay":
         goodness_per_label = []
         for label in range(10):
             h = overlay_y_on_x(x, label)
             goodness = []
             for module in model.children():
-                h = h.to(device)
-                # module.to(device)
+                module.to(device)
                 h = module(h)
-                # module.to('cpu')
                 goodness += [h.pow(2).mean(1)]
+                module.to('cpu')
             goodness_per_label += [sum(goodness).unsqueeze(1)]
         goodness_per_label = torch.cat(goodness_per_label, 1)
-        # print(f"goodness: {goodness_per_label}")
         return goodness_per_label.argmax(1)
 
 
-# def eval_loop(model, train_loader, encoding="overlay"):
-#     if encoding == "overlay":
-#         for x, _ in train_loader:
-#             for label in range(10):
-#                 h = overlay_y_on_x(x, label)
-#                 goodness = []
-#                 for module in model.children():
-#                     h = module(h)
-#                     goodness += h.pow(2).mean(1)
-                
-            
-
-def test_loop(model, test_loader, device):
-    model.eval()
-    batch_error = 0
-    for x, y in test_loader:
-        x, y = x.to(device), y.to(device)
-        batch_error += calc_error(model, x, y)
-    
-    avg_error = batch_error / len(test_loader)
-    print(avg_error)
-
 def calc_error(model, x, y, device) -> float:
     model.eval()
-    r1 = eval_loop(model, x)
-    r1 = r1.to('cuda')
-    y = y.to('cuda')
-    r2 = r1.eq(y).float().mean().item()
-    r = 1 - r2
-    return r
+    return 1 - eval_loop(model, x, device).eq(y).float().mean().item()
 
 
-torch.manual_seed(1234)
-train_loader, test_loader = MNIST_loaders()
+if __name__ == "__main__":
+    # Define parameters
+    EPOCHS = 10
+    BATCH_SIZE=50
+    TRAIN_BATCH_SIZE = BATCH_SIZE
+    TEST_BATCH_SIZE = BATCH_SIZE
+    encoding = "overlay"
+    torch.manual_seed(1234)
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    # Build train and test loaders
+    train_loader, test_loader = MNIST_loaders(train_batch_size=TRAIN_BATCH_SIZE, test_batch_size=TEST_BATCH_SIZE)
 
-net = FFNetwork([784, 500, 500])
-# net = net.to(device)
-# x, y = next(iter(train_loader))
-# x, y = x.to(device), y.to(device)
+    # Define device
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
 
-# training_loop(net, x, y)
-training_loop(net, train_loader, device)
-# net.eval()
-# print(calc_error(net, x, y))
+    # Build network
+    net = FFNetwork([784, 500, 500])
 
-# x_te, y_te = next(iter(test_loader))
-# x_te, y_te = x_te.cuda(), y_te.cuda()
+    # Iterator in place of DataLoader
+    data_iter = []
 
-# USE EVAL
-# net.eval()
-# print(calc_error(net, x_te, y_te))
-test_loop(net, test_loader, device)
+    # Encode true and false labels on images to create positive and negative data
+    print("Encoding positive and negative data with correct and incorrect labels")
+    for x, y in tqdm(train_loader):
+        x, y = x.to(device), y.to(device)
+        x_pos, x_neg = None, None
+        if encoding == "overlay":
+            x_pos = overlay_y_on_x(x, y)
+            rand_mask = torch.randint(0, 9, y.size()).to(device)
+            y_rnd = (y + rand_mask + 1) % 10
+            x_neg = overlay_y_on_x(x, y_rnd)
+        x, y = x.to('cpu'), y.to('cpu')
+        x_pos, x_neg = x_pos.to('cpu'), x_neg.to('cpu')
+        data_iter.append((x_pos, x_neg))
+
+    # Train / test
+    for epoch in range(EPOCHS):
+        print(f"==== EPOCH: {epoch} ====")
+        start = time.time()
+        training_loop(net, data_iter, device)
+        test_loop(net, test_loader, device)
+        end = time.time()
+        elapsed = end - start
+        print(f"Completed epoch {epoch} in {elapsed} seconds")
+

--- a/base.py
+++ b/base.py
@@ -6,7 +6,7 @@ from torchvision.transforms import Compose, ToTensor, Normalize, Lambda
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from FFNetwork import FFNetwork
+from FFNetwork import FFNetworkBatched
 from FFEncoding import FFEncoding
 
 overlay_y_on_x = FFEncoding.overlay
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     print(f"Using device: {device}")
 
     # Build network
-    net = FFNetwork([784, 500, 500])
+    net = FFNetworkBatched([784, 500, 500])
 
     # Iterator in place of DataLoader
     data_iter = []


### PR DESCRIPTION
Note: Training and testing loops are slightly different in how they handle moving layers and batches on/off cuda
Training:
1. Move layer on cuda
2. Loop through batches, move each on cuda, training, then move off
3. Move layer off cuda
4. Move next layer on cuda
5. etc.

Testing loop:
1. Move batch on cuda
2. Move first layer on cuda, accumulate goodness
3. Move next layer on cuda, accumulate goodness, etc.
4. Move batch off cuda
5. Move next batch on cuda
6. etc.

This difference is due to how evaluation works - evaluating accumulates goodness over layers, so we have to save both the output of each layer and it's calculated 'goodness', to pass the output to the next layer and accumulate goodness over all layers. It would be possible to change this format to be the same as the training loop, but would require some sort of new dataloader/iterator type of class to associate the input (e.g. an image) to the output and 'goodness' of each layer.